### PR TITLE
bugfix autofocus filename corruption

### DIFF
--- a/camera.c
+++ b/camera.c
@@ -1077,7 +1077,8 @@ int doCameraAndAstrometry() {
     static int num_focus_pos;
     static int * blob_mags;
     int blob_count;
-    char datafile[100], buff[100], date[256], af_filename[256];
+    char datafile[100], buff[100], date[256];
+    static char af_filename[256];
     wchar_t filename[200] = L"";
     struct timespec camera_tp_beginning, camera_tp_end; 
     time_t seconds = time(NULL);


### PR DESCRIPTION
### Issue Description

When attempting to find the optimal focus position after collecting autofocusing data, the optimal focus is not found.

### Expected Behavior

Calculation of optimal focus position succeeds with no errors.

### Actual Behavior

A file not found error printed to terminal, and the program continues taking images after failing to autofocus.

### Proposed Fix

This issue is a result of the `camera.c:af_filename` variable being overwritten between calls to `doCameraAndAstrometry()`. Because `af_filename` is a `char` array declared on the stack at the beginning of each call to `doCameraAndAstrometry()`, the memory it occupies may be overwritten when it goes out of scope. `af_filename` is defined only once for each run of the autofocusing subroutine: on the first iteration, by a `strftime()` call. However, the address of the array `af_filename` is passed to `calculateOptimalFocus()` as an argument many calls to `doCameraAndAstrometry()` later, after the autofocusing subroutine finishes taking its last image! After the first call to `doCameraAndAstrometry()`, the memory `af_filename` points to is free to be overwritten by another process, and if it is, the `char` array passed to  `calculateOptimalFocus()` may be wholly or partially garbage. When this array is `fopen()`'d in `calculateOptimalFocus()`, the error referenced above may be seen.

This undefined behavior is fixed by declaring `af_filename` static.